### PR TITLE
プロトタイプ詳細機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -4,12 +4,15 @@ class PrototypesController < ApplicationController
   def index
     @prototypes = Prototype.includes(:user)
   end
-
-  def edit
-  end
   
   def new
     @prototype = Prototype.new
+  end
+
+  def edit
+  end
+
+  def destroy
   end
 
   def create
@@ -23,6 +26,7 @@ class PrototypesController < ApplicationController
   end
 
   def show
+    @prototype = Prototype.find(params[:id])
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [:index ]
+  before_action :move_to_index, except: [:index, :show ]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), root_path%>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.id)%>
   <div class="card__body">
-    <%= link_to prototype.title, root_path, class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype.id), class: :card__title%>
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -2,9 +2,9 @@
   <div class="inner">
     <div class="prototype__wrapper">
       <p class="prototype__hedding">
-        <%= "プロトタイプのタイトル"%>
+        <%= @prototype.title %>
       </p>
-      <%= link_to "by プロトタイプの投稿者", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
       <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
@@ -12,19 +12,19 @@
         </div>
       <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">
-        <%= image_tag "プロトタイプの画像" %>
+        <%= image_tag @prototype.image %>
       </div>
       <div class="prototype__body">
         <div class="prototype__detail">
           <p class="detail__title">キャッチコピー</p>
           <p class="detail__message">
-            <%= "プロトタイプのキャッチコピー" %>
+            <%= @prototype.catch_copy %>
           </p>
         </div>
         <div class="prototype__detail">
           <p class="detail__title">コンセプト</p>
           <p class="detail__message">
-            <%= "プロトタイプのコンセプト" %>
+            <%= @prototype.concept %>
           </p>
         </div>
       </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -5,12 +5,12 @@
         <%= @prototype.title %>
       </p>
       <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
-      <%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
+      <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
-      <%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
+      <% end %>
       <div class="prototype__image">
         <%= image_tag @prototype.image %>
       </div>


### PR DESCRIPTION
## What
下記機能を実装
・プロトタイプ詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。
・プロトタイプ一覧ページにてプロトタイプ情報をクリックすると、該当するプロトタイプの詳細表示ページへ遷移すること。
・プロトタイプ投稿時に登録した情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト）が表示されること。
・画像が表示されており、画像がリンク切れなどにならないこと。（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）
・ログイン状態且つ、自身が投稿した場合にのみ、「編集する」「削除する」ボタンが表示されること。
・ログイン状態の場合でも、自身が投稿していない場合は、「編集する」「削除する」ボタンが表示されないこと。
・ログアウト状態の場合では、「編集する」「削除する」ボタンが表示されないこと。

## Why
プロトタイプの詳細情報を表示機能の実装のため

## 確認
・プロトタイプ詳細表示（ログイン・ログアウト）※ログイン確認は、ログイン状態且つ自身が投稿した場合
https://gyazo.com/ac6af2cd71d7f1b87d6c3ffaa5046815

・ログイン状態の場合でも、自身が投稿していない
https://gyazo.com/cef2a24be69e9342349850871ca5b7c5

