### PR TITLE
プロトタイプ情報削除機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,5 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [:index, :show ]
+  before_action :move_to_index, except: [:index, :show, :destroy ]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -13,6 +13,9 @@ class PrototypesController < ApplicationController
   end
 
   def destroy
+    prototype = Prototype.find(params[:id])
+    prototype.destroy
+    redirect_to root_path
   end
 
   def create

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
   before_action :move_to_index, except: [:index, :show, :destroy ]
+  before_action :move_check, only: [ :destroy ]
 
   def index
     @prototypes = Prototype.includes(:user)
@@ -39,6 +40,14 @@ class PrototypesController < ApplicationController
   
   def move_to_index
     unless user_signed_in?
+      redirect_to action: :index
+    end
+  end
+
+  def move_check
+    if !user_signed_in?
+      redirect_to new_user_session_path and return
+    elsif user_signed_in? && current_user.id != Prototype.find(params[:id]).user_id
       redirect_to action: :index
     end
   end

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path, data: { turbo_method: :delete }, class: :prototype__btn %>
         </div>
       <% end %>
       <div class="prototype__image">


### PR DESCRIPTION
What
下記機能を実装
・ログイン状態の場合にのみ、詳細ページから「削除する」ボタンをクリックすると、自身が投稿したプロトタイプ情報を削除できること。
・削除が完了すると、トップページへ遷移すること。
・ログアウト状態で削除しようとした場合、ログインページにリダイレクトされること。

Why
プロトタイプの情報を削除する機能の実装のため

確認
・削除確認（自身が投稿しているもののみ且つログアウト状態はログイン画面へ遷移）
※一時的にログイン状態確認による「編集」「削除」をコメントアウトしてます
https://gyazo.com/2dbe8b433b2263102daeb07f1bb4ecb0