### PR TITLE
プロトタイプ編集機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,5 +1,6 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [:index, :show ]
+  before_action :move_to_index, except: [:index, :show, :edit ]
+  before_action :authenticate_user!, only: [:edit ]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -34,8 +34,8 @@ class PrototypesController < ApplicationController
   end
 
   def update
-    prototype = Prototype.find(params[:id]) 
-      if prototype.update(create_params_setting)
+    @prototype = Prototype.find(params[:id]) 
+      if @prototype.update(create_params_setting)
         redirect_to action: :show
       else
         render :edit, status: :unprocessable_entity

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -34,7 +34,7 @@ class PrototypesController < ApplicationController
   end
 
   def update
-    @prototype = Prototype.find(params[:id]) 
+    @prototype = Prototype.find(params[:id])
       if @prototype.update(create_params_setting)
         redirect_to action: :show
       else

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -10,6 +10,7 @@ class PrototypesController < ApplicationController
   end
 
   def edit
+    @prototype = Prototype.find(params[:id])
   end
 
   def destroy
@@ -27,6 +28,15 @@ class PrototypesController < ApplicationController
 
   def show
     @prototype = Prototype.find(params[:id])
+  end
+
+  def update
+    prototype = Prototype.find(params[:id]) 
+      if prototype.update(create_params_setting)
+        redirect_to action: :show
+      else
+        render :edit, status: :unprocessable_entity
+      end
   end
 
   private

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -11,6 +11,9 @@ class PrototypesController < ApplicationController
 
   def edit
     @prototype = Prototype.find(params[:id])
+    unless current_user.id == @prototype.user_id
+      redirect_to root_path
+    end
   end
 
   def destroy

--- a/app/views/prototypes/edit.html.erb
+++ b/app/views/prototypes/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="inner">
     <div class="form__wrapper">
       <h2 class="page-heading">プロトタイプ編集</h2>
-      <%# 部分テンプレートでフォームを表示する %>
+      <%= render partial: "form", locals: { prototype: @prototype } %>
     </div>
   </div>
 </div>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,7 +7,7 @@
       <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
           <%= link_to "削除する", root_path, class: :prototype__btn %>
         </div>
       <% end %>

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -8,7 +8,7 @@
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
           <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path, data: { turbo_method: :delete }, class: :prototype__btn %>
         </div>
       <% end %>
       <div class="prototype__image">


### PR DESCRIPTION
# What
プロトタイプ編集機能を作成(以下に実装条件を表記)

・必要な情報を適切に入力して「保存する」ボタンを押すと、
　プロトタイプ情報（画像・プロトタイプ名・キャッチコピー）を編集できること。

・何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならないこと。

・ログイン状態の場合は、自身が投稿したプロトタイプ情報編集ページに遷移できること。

・ログイン状態の場合でも、自身が投稿していないプロトタイプのプロトタイプ情報編集ページへ遷移しようとすると、
　トップページに遷移すること。

・ログアウト状態の場合は、プロトタイプ情報編集ページへ遷移しようとすると、ログインページに遷移すること。

・プロトタイプ投稿時とほぼ同じ見た目のプロトタイプ情報編集ページが表示されること。

・プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示されること。
　（画像は表示されない状態で良い）

・空の入力欄がある場合は、編集できずにそのページに留まること。

・バリデーションによって編集ができず、そのページに留まった場合でも、入力済みの項目（画像以外）は消えないこと。

・正しく編集できた場合は、プロトタイプ詳細ページへ遷移すること。


# Why
プロトタイプ編集機能を実装するため

# 確認動画
・ログイン状態の投稿者は、プロトタイプ情報編集ページに遷移できる動画
https://gyazo.com/2652529c77f8e403395aaf4798ab9c82

・必要な情報を適切に入力して「保存する」ボタンを押すと、プロトタイプの情報を編集できる動画
https://gyazo.com/d3b6ad2162448a68fe038e6d93d938ae

・入力に問題がある状態で「保存する」ボタンが押された場合、情報は保存されず、そのページに留まる動画
https://gyazo.com/4c44a224ffffdefe28898502c13b6be8

・何も編集せずに「保存する」ボタンを押しても、画像無しのプロトタイプにならない動画
https://gyazo.com/3f77224cfcb446879376d88a70313e21

・ログイン状態の場合でも、URLを直接入力して自身が投稿していないプロトタイプの
　プロトタイプ情報編集ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/ffdd9230e052b1b672bd4c788f47b683

・ログアウト状態の場合は、URLを直接入力してプロトタイプ情報編集ページへ遷移しようとすると、
　ログインページに遷移する動画
https://gyazo.com/a540ddb35422ea5bdb8a1ca1b899c1a3

・プロトタイプ情報について、すでに登録されている情報は、編集画面を開いた時点で表示される動画
https://gyazo.com/25ee91e4f6fa96fb9825c718a05999bb
