### PR TITLE
ユーザー詳細ページ機能

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [ :index, :show, :destroy, :edit ]
+  before_action :move_to_index, except: [ :index, :show, :destroy, :edit, :new ]
   before_action :move_check, only: [ :edit, :destroy ]
+  before_action :authenticate_user!, :only [ :new ]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,7 +1,6 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [ :index, :show, :destroy, :edit, :new ]
+  before_action :move_to_index, except: [ :index, :show, :destroy, :edit ]
   before_action :move_check, only: [ :edit, :destroy ]
-  before_action :authenticate_user!, :only [ :new ]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -1,6 +1,7 @@
 class PrototypesController < ApplicationController
-  before_action :move_to_index, except: [ :index, :show, :destroy, :edit ]
+  before_action :move_to_index, except: [ :index, :show, :destroy, :edit, :new ]
   before_action :move_check, only: [ :edit, :destroy ]
+  before_action :authenticate_user!, only: [ :new ]
 
   def index
     @prototypes = Prototype.includes(:user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.includes(:prototypes).find(params[:id])
+  end
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/prototype.rb
+++ b/app/models/prototype.rb
@@ -1,18 +1,12 @@
 class Prototype < ApplicationRecord
-  # 空の場合は登録できない
+  has_one_attached :image
+  belongs_to :user
+  has_many :comments, dependent: :destroy
+
   with_options presence: true do
     validates :title
     validates :catch_copy
     validates :concept
+    validates :image
   end
-
-  has_one_attached :image
-  validate :was_attached?
-  def was_attached?
-    self.image.attached?
-  end
-
-    belongs_to :user
-    has_many :comments, dependent: :destroy
-
 end

--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -5,6 +5,6 @@
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>
-    <%= link_to "by #{prototype.user.name}", root_path, class: :card__user %>
+    <%= link_to "by #{prototype.user.name}", user_path(prototype.user_id), class: :card__user %>
   </div>
 </div>

--- a/app/views/prototypes/index.html.erb
+++ b/app/views/prototypes/index.html.erb
@@ -4,7 +4,7 @@
     <% if user_signed_in? %>
       <div class="greeting"> 
         <%= "こんにちは、" %>
-        <%= link_to "#{current_user.name}さん", root_path, class: :greeting__link%>
+        <%= link_to "#{current_user.name}さん", user_path(current_user.id), class: :greeting__link%>
       </div>
     <% end %>
 

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -4,11 +4,11 @@
       <p class="prototype__hedding">
         <%= @prototype.title %>
       </p>
-      <%= link_to "by #{@prototype.user.name}", root_path, class: :prototype__user %>
+      <%= link_to "by #{@prototype.user.name}", user_path(@prototype.user_id), class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %>
         <div class="prototype__manage">
-          <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
-          <%= link_to "削除する", prototype_path, data: { turbo_method: :delete }, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path(@prototype.id), class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete }, class: :prototype__btn %>
         </div>
       <% end %>
       <div class="prototype__image">
@@ -44,7 +44,7 @@
            <% @comments.each do |comment| %>
             <li class="comments_list">
               <%= comment.text %>
-              <%= link_to comment.user.name, "/users/#{comment.user_id}", class: :comment_user %>
+              <%= link_to comment.user.name, user_path(comment.user_id), class: :comment_user %>
             </li>
            <% end %>
         </ul>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -2,34 +2,34 @@
   <div class="inner">
     <div class="user__wrapper">
       <h2 class="page-heading">
-        <%= "ユーザー名さんの情報"%>
+        <%= "#{@user.name}さんの情報"%>
       </h2>
       
       <table class="table">
         <tbody>
           <tr>
             <th class="table__col1">名前</th>
-            <td class="table__col2"><%= "ユーザー名" %></td>
+            <td class="table__col2"><%= @user.name %></td>
           </tr>
           <tr>
             <th class="table__col1">プロフィール</th>
-            <td class="table__col2"><%= "ユーザーのプロフィール" %></td>
+            <td class="table__col2"><%= @user.profile %></td>
           </tr>
           <tr>
             <th class="table__col1">所属</th>
-            <td class="table__col2"><%= "ユーザーの所属" %></td>
+            <td class="table__col2"><%= @user.occupation %></td>
           </tr>
           <tr>
             <th class="table__col1">役職</th>
-            <td class="table__col2"><%= "ユーザーの役職" %></td>
+            <td class="table__col2"><%= @user.position %></td>
           </tr>
         </tbody>
       </table>
       <h2 class="page-heading">
-        <%= "ユーザー名さんのプロトタイプ"%>
+        <%= "#{@user.name}さんのプロトタイプ"%>
       </h2>
       <div class="user__card">
-        <%# 部分テンプレートでそのユーザーが投稿したプロトタイプ投稿一覧を表示する %>
+        <%= render partial: 'prototypes/prototype', collection: @user.prototypes, as: :prototype %>
       </div>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Rails.application.routes.draw do
   #get 'prototypes/index'
   root to: "prototypes#index"
   devise_for :users
+  resources :users, only: :show
   
-  # プロトタイプの中身にコメントを表示するため下記のように記載する
   resources :prototypes do
     resources :comments, only: :create
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## What
下記機能を実装
・ユーザー詳細表示ページは、ログイン状況に関係なく、誰でも見ることができること。
・各ページのユーザー名をクリックすると、該当ユーザーの詳細ページへ遷移すること。
・ユーザーの詳細ページには、そのユーザーの詳細情報（名前・プロフィール・所属・役職）が表示されていること。
・ユーザーの詳細ページには、そのユーザーが投稿したプロトタイプの情報（プロトタイプ名・投稿者・画像・キャッチコピー・コンセプト※恐らくコンセプトは不要）が表示されていること。
・プロトタイプ情報の画像が表示されており、画像がリンク切れなどになっていないこと（Renderの仕様による画像のリンク切れは、要件未達に含まれない。Render上では一定時間経過すると画像が消える。）

## Why
ユーザー詳細表示ページにて、ユーザーの詳細情報を表示する機能の実装のため

## 確認
・ユーザー詳細表示ページ表示（ログイン状態）
https://gyazo.com/c4e7f169b50d4eff8a7c845fb63b4bb0
・ユーザー詳細表示ページ表示（ログアウト状態）
https://gyazo.com/acf5355de1b1531b923a5669f21743dd
